### PR TITLE
add the <url> field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     </properties>
     <name>Mac Plugin</name>
     <description>A plugin to configure Mac as a Jenkins slaves</description>
+    <url>https://github.com/jenkinsci/mac-plugin/</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
add the `<url>` field so that plugin docs points to GitHub
see https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/#how-to-enable-github-documentation-for-your-plugin