### PR TITLE
Copy ~/.ssh/environment file foreach agent

### DIFF
--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
@@ -37,6 +37,7 @@ class MacHost implements Describable<MacHost> {
     Integer agentConnectionTimeout
     Integer maxTries
     Boolean disabled
+    Boolean copySSHEnvFile
     Boolean uploadKeychain = Boolean.FALSE
     String labelString
     String fileCredentialsId
@@ -46,7 +47,8 @@ class MacHost implements Describable<MacHost> {
 
     @DataBoundConstructor
     MacHost(String host, String credentialsId, Integer port, Integer maxUsers, Integer connectionTimeout, Integer readTimeout, Integer agentConnectionTimeout,
-    Boolean disabled, Integer maxTries, String labelString, Boolean uploadKeychain, String fileCredentialsId, List<MacEnvVar> envVars, String key) {
+            Boolean disabled, Integer maxTries, String labelString, Boolean uploadKeychain, String fileCredentialsId, List<MacEnvVar> envVars, String key,
+            Boolean copySSHEnvFile) {
         this.host = host
         this.credentialsId = credentialsId
         this.port = port
@@ -62,6 +64,7 @@ class MacHost implements Describable<MacHost> {
         this.uploadKeychain = uploadKeychain ?: Boolean.FALSE
         this.fileCredentialsId = fileCredentialsId
         this.macHostKeyVerifier = new MacHostKeyVerifier(key)
+        this.copySSHEnvFile = copySSHEnvFile
         labelSet = Label.parse(StringUtils.defaultIfEmpty(labelString, ""))
     }
     

--- a/src/main/java/fr/edf/jenkins/plugins/mac/connector/MacComputerJNLPConnector.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/connector/MacComputerJNLPConnector.groovy
@@ -87,7 +87,9 @@ class MacComputerJNLPConnector extends MacComputerConnector {
                     FileCredentials fileCredentials = CredentialsUtils.findFileCredentials(host.fileCredentialsId, Jenkins.get())
                     SSHCommand.uploadKeychain(host, user, fileCredentials)
                 }
-                SSHCommand.copySSHEnvironmentVarsFile(host, user)
+                if (host.copySSHEnvFile) {
+                    SSHCommand.copySSHEnvironmentVarsFile(host, user)
+                }
                 SSHCommand.jnlpConnect(host, user, jenkinsUrl, computer.getJnlpMac())
             }catch(Exception e) {
                 launched = false

--- a/src/main/java/fr/edf/jenkins/plugins/mac/connector/MacComputerJNLPConnector.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/connector/MacComputerJNLPConnector.groovy
@@ -87,6 +87,7 @@ class MacComputerJNLPConnector extends MacComputerConnector {
                     FileCredentials fileCredentials = CredentialsUtils.findFileCredentials(host.fileCredentialsId, Jenkins.get())
                     SSHCommand.uploadKeychain(host, user, fileCredentials)
                 }
+                SSHCommand.copySSHEnvironmentVarsFile(host, user)
                 SSHCommand.jnlpConnect(host, user, jenkinsUrl, computer.getJnlpMac())
             }catch(Exception e) {
                 launched = false

--- a/src/main/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommand.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommand.groovy
@@ -152,7 +152,7 @@ class SSHCommand {
                     readTimeout: macHost.readTimeout, kexTimeout: macHost.kexTimeout, macHostKeyVerifier: macHost.macHostKeyVerifier)
             LOGGER.log(Level.FINE, SSHCommandLauncher.executeCommand(connectionConfig, true, MessageFormat.format(Constants.COPY_SSH_ENVIRONMENT, user.username)))
         } catch(Exception e) {
-            final String message = String.format(SSHCommandException.CREATE_MAC_USER_ERROR_MESSAGE, macHost.host)
+            final String message = String.format(SSHCommandException.COPY_SSH_ENVIRONMENT_ERROR_MESSAGE, macHost.host)
             LOGGER.log(Level.SEVERE, message, e)
             throw new SSHCommandException(message, e)
         }

--- a/src/main/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommand.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommand.groovy
@@ -3,6 +3,7 @@ package fr.edf.jenkins.plugins.mac.ssh
 import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import java.util.logging.Logger
+import java.text.MessageFormat;
 
 import org.apache.commons.lang.RandomStringUtils
 import org.apache.commons.lang.StringUtils
@@ -138,6 +139,20 @@ class SSHCommand {
             return true
         } catch(Exception e) {
             final String message = String.format(SSHCommandException.TRANSFERT_KEYCHAIN_ERROR_MESSAGE, host.host, e.getMessage())
+            LOGGER.log(Level.SEVERE, message, e)
+            throw new SSHCommandException(message, e)
+        }
+    }
+
+    @Restricted(NoExternalUse)
+    static boolean copySSHEnvironmentVarsFile(MacHost macHost, MacUser user) throws SSHCommandException, Exception {
+        try {
+            SSHGlobalConnectionConfiguration connectionConfig = new SSHGlobalConnectionConfiguration(credentialsId: macHost.credentialsId, port: macHost.port,
+                    context: Jenkins.get(), host: macHost.host, connectionTimeout: macHost.connectionTimeout,
+                    readTimeout: macHost.readTimeout, kexTimeout: macHost.kexTimeout, macHostKeyVerifier: macHost.macHostKeyVerifier)
+            LOGGER.log(Level.FINE, SSHCommandLauncher.executeCommand(connectionConfig, true, MessageFormat.format(Constants.COPY_SSH_ENVIRONMENT, user.username)))
+        } catch(Exception e) {
+            final String message = String.format(SSHCommandException.CREATE_MAC_USER_ERROR_MESSAGE, macHost.host)
             LOGGER.log(Level.SEVERE, message, e)
             throw new SSHCommandException(message, e)
         }

--- a/src/main/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommandException.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommandException.groovy
@@ -22,6 +22,9 @@ class SSHCommandException extends Exception {
     /** Cannot transfert keychain file %s on mac %s */
     public static final String TRANSFERT_KEYCHAIN_ERROR_MESSAGE = "Cannot transfert keychain file on mac %s : %s"
 
+    /** Cannot copy ~/.ssh/environment file on host %s */
+    public static final String COPY_SSH_ENVIRONMENT_ERROR_MESSAGE = "Cannot copy ~/.ssh/environment file on host %s"
+
     /**
      * Constructor with message and cause
      * @param message

--- a/src/main/java/fr/edf/jenkins/plugins/mac/util/Constants.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/util/Constants.groovy
@@ -55,6 +55,9 @@ class Constants {
     /** mkdir %s */
     public static final String CREATE_DIR = "mkdir %s"
 
+    /** sudo mkdir -p /Users/{0}/.ssh && sudo cp ~/.ssh/environment /Users/{0}/.ssh/environment && sudo chown {0} /Users/{0}/.ssh/environment */
+    public static final String COPY_SSH_ENVIRONMENT = "sudo mkdir -p /Users/{0}/.ssh && sudo cp ~/.ssh/environment /Users/{0}/.ssh/environment && sudo chown {0} /Users/{0}/.ssh/environment"
+
     //regex
     public static final String REGEX_NEW_LINE = "\\r?\\n|\\r"
 

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
@@ -68,6 +68,10 @@ f.advanced(title:Messages.Host_Details()) {
         }
     }
 
+    f.entry(title: Messages.Host_CopySSHEnvFile(), field:'copySSHEnvFile') {
+        f.checkbox()
+    }
+
     f.entry(title: _(Messages.EnvVar_Title())) {
         f.repeatableHeteroProperty(
                 field:'envVars',

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/help-copySSHEnvFile.html
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/help-copySSHEnvFile.html
@@ -1,0 +1,3 @@
+<div>
+    Copy original prepared ~/.ssh/environment file to node users to have same predefined ENV variables
+</div>

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
@@ -31,6 +31,7 @@ Host.TestConnection=Test Connection
 Host.ConnectionSucceeded=Connected as {0}
 Host.ConnectionFailed=Connection failed : {0}
 Host.Disabled=Disabled
+Host.CopySSHEnvFile=Copy ~/.ssh/environment file
 Host.MaxTries=Max connection retries
 Host.Details=Host details
 

--- a/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
@@ -29,7 +29,8 @@ class MacPojoBuilder {
                 Boolean.FALSE, //
                 null ,
                 buildEnvVars(), //envVars
-                "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZw==" //macHostKeyVerifier
+                "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZw==", //macHostKeyVerifier
+                false // copySSHEnvFile
                 )
         List<MacHost> hostList = new ArrayList()
         hostList.add(host)


### PR DESCRIPTION
Here is a useful feature to allow copy predefined file with environment vars from the source user to every new agent

Basically, it copies file `~/.ssh/environment` to new user `/Users/<agent>/.ssh/environment`

This can be configured from Mac Cloud set preferences page