### PR TITLE
Support for copying file from Jenkins host to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,28 @@ A good utility to build yours IOS apps, this plugin create MacOs agents for your
 It can stock your Keychains file on Jenkins and send it to the MacOs Nodes.
 
 ## Table of Contents
-- [Features](#features)
-- [Requirements](#requirements)
-    - [Jenkins](#jenkins)
-    - [MacOs](#macos)
-       - [Enable SSH for all users](#enable-ssh-for-all-users)
-       - [SSH configuration](#ssh-configuration)
-       - [Configure a Jenkins User](#configure-a-jenkins-user)
-- [Plugin configuration](#plugin-configuration)
-    - [Global Configuration](#global-configuration)
-    - [Keychain Managment](#keychain-managment)
-    - [Environment variables](#environment-variables)
-    - [Pre-launch commands](#pre-launch-commands)
-    - [Web Socket](#web-socket)
-    - [User Management Tool](#user-management-tool)
-- [Logs configuration](#logs-configuration)
-- [Execution](#execution)
-- [Troubleshooting](#troubleshooting)
-- [Team](#team)
-- [Contact](#contact)
+- [Mac Plugin](#mac-plugin)
+	- [Table of Contents](#table-of-contents)
+	- [Features](#features)
+	- [Requirements](#requirements)
+		- [Jenkins](#jenkins)
+		- [MacOS](#macos)
+			- [Enable SSH for all users](#enable-ssh-for-all-users)
+			- [SSH configuration](#ssh-configuration)
+			- [Configure a Jenkins User](#configure-a-jenkins-user)
+	- [Plugin configuration](#plugin-configuration)
+		- [Global Configuration](#global-configuration)
+		- [Keychain Managment](#keychain-managment)
+		- [Environment variables](#environment-variables)
+		- [Host files](#host-files)
+		- [Pre-launch commands](#pre-launch-commands)
+		- [Web Socket](#web-socket)
+		- [User Management Tool](#user-management-tool)
+	- [Logs configuration](#logs-configuration)
+	- [Execution](#execution)
+	- [Troubleshooting](#troubleshooting)
+	- [Team](#team)
+	- [Contact](#contact)
 
 ## Features
 
@@ -136,6 +139,9 @@ The Keychain will be send to the Mac agent with SCP in ~/Library/Keychains/ dire
 Since v1.1.0, you can set environment variables on Mac host. Theses variables will be set on the Node and will be accessible in the build.
 
 <img src="https://zupimages.net/up/19/50/i14g.png" width="650"/>
+
+### Host files
+You can upload files (defined as Jenkins' credentials file type) to a path relative to the user's home folder
 
 ### Pre-launch commands
 Since v1.3.0, you can set commands passed to the user before the agent starts.

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
@@ -47,11 +47,12 @@ class MacHost implements Describable<MacHost> {
     MacHostKeyVerifier macHostKeyVerifier
     transient Set<LabelAtom> labelSet
     String userManagementTool
+    List<MacHostFile> hostFiles = new ArrayList()
 
     @DataBoundConstructor
     MacHost(String host, String credentialsId, Integer port, Integer maxUsers, Integer connectionTimeout, Integer readTimeout, Integer agentConnectionTimeout,
     Boolean disabled, Integer maxTries, String labelString, Boolean uploadKeychain, String fileCredentialsId, List<MacEnvVar> envVars, String key,
-    String preLaunchCommands, String userManagementTool, String agentJvmParameters) {
+    String preLaunchCommands, String userManagementTool, String agentJvmParameters, List<MacHostFile> hostFiles) {
         this.host = host
         this.credentialsId = credentialsId
         this.port = port
@@ -70,6 +71,7 @@ class MacHost implements Describable<MacHost> {
         this.preLaunchCommandsList = buildPreLaunchCommands(preLaunchCommands)
         this.userManagementTool = userManagementTool
         this.agentJvmParameters = agentJvmParameters
+        this.hostFiles = hostFiles
         labelSet = Label.parse(StringUtils.defaultIfEmpty(labelString, ""))
     }
 
@@ -272,7 +274,7 @@ class MacHost implements Describable<MacHost> {
         }
 
         /**
-         * Verify the connection to the Mac machine 
+         * Verify the connection to the Mac machine
          * @param host
          * @param port
          * @param credentialsId

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacHostFile.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacHostFile.groovy
@@ -1,0 +1,65 @@
+package fr.edf.jenkins.plugins.mac
+
+import org.kohsuke.stapler.DataBoundConstructor
+import org.kohsuke.stapler.DataBoundSetter
+import org.kohsuke.stapler.AncestorInPath
+import org.kohsuke.stapler.QueryParameter
+import org.kohsuke.stapler.verb.POST
+
+import fr.edf.jenkins.plugins.mac.util.FormUtils
+
+import hudson.Extension
+import hudson.model.Describable
+import hudson.model.Descriptor
+import hudson.model.Item
+import jenkins.model.Jenkins
+import hudson.util.ListBoxModel
+
+class MacHostFile implements Describable<MacHostFile> {
+    String hostFileCredentialsId
+    String hostPath
+
+    @DataBoundConstructor
+    MacHostFile(String hostFileCredentialsId, String hostPath) {
+        this.hostFileCredentialsId = hostFileCredentialsId
+        this.hostPath = hostPath
+    }
+
+    @DataBoundSetter
+    setHostFileCredentialsId(String hostFileCredentialsId) {
+        this.hostFileCredentialsId = hostFileCredentialsId
+    }
+
+    @DataBoundSetter
+    setHostPath(String hostPath) {
+        this.hostPath = hostPath
+    }
+
+    @Override
+    public Descriptor<MacHostFile> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(this.getClass())
+    }
+
+    @Extension
+    static class DescriptorImpl extends Descriptor<MacHostFile> {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        String getDisplayName() {
+            return Messages.HostFile_DisplayName()
+        }
+
+
+        /**
+         * Return ListBoxModel of existing secret files
+         * @param credentialsId
+         * @param context
+         * @return ListBoxModel
+         */
+        @POST
+        ListBoxModel doFillHostFileCredentialsIdItems(@QueryParameter String fileCredentialsId, @AncestorInPath Item ancestor) {
+            return FormUtils.newFileCredentialsItemsListBoxModel(fileCredentialsId, ancestor)
+        }
+    }
+}

--- a/src/main/java/fr/edf/jenkins/plugins/mac/connector/MacComputerJNLPConnector.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/connector/MacComputerJNLPConnector.groovy
@@ -115,6 +115,12 @@ class MacComputerJNLPConnector extends MacComputerConnector {
                     listener.logger.print("Launching entry point cmd")
                     SSHCommand.launchPreLaunchCommand(host, user)
                 }
+                if (host.hostFiles) {
+                    host.hostFiles.each { hostFile ->
+                        FileCredentials fileCredentials = CredentialsUtils.findFileCredentials(hostFile.hostFileCredentialsId, Jenkins.get())
+                        SSHCommand.uploadHostFile(host, user, fileCredentials, hostFile.hostPath)
+                    }
+                }
                 SSHCommand.jnlpConnect(host, user, jenkinsUrl, computer.getJnlpMac())
             }catch(Exception e) {
                 launched = false

--- a/src/main/java/fr/edf/jenkins/plugins/mac/util/Constants.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/util/Constants.groovy
@@ -122,6 +122,9 @@ class Constants {
     /** /Users/%s/Library/Keychains/ */
     public static final String KEYCHAIN_DESTINATION_FOLDER = "/Users/%s/Library/Keychains/"
 
+    /** /Users/%s/ */
+    public static final String HOST_FILE_DESTINATION_BASE_FOLDER = "/Users/%s/"
+
     //     Command for grouping users on a mac (not used but keep for potential evol)
     //    /** sudo dseditgroup -o create %s */
     //    public static final String CREATE_GROUP = "sudo dseditgroup -o create %s"

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
@@ -94,4 +94,14 @@ f.advanced(title:Messages.Host_Details()) {
                 repeatableDeleteButton:'true'
                 )
     }
+
+    f.entry(title: _(Messages.Host_File())) {
+        f.repeatableHeteroProperty( field:'hostFiles',
+                hasHeader: 'true',
+                addCaption: Messages.HostFile_Add(),
+                deleteCaption:Messages.HostFile_Delete(),
+                oneEach:'false',
+                repeatableDeleteButton:'true'
+        )
+    }
 }

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHostFile/config.groovy
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHostFile/config.groovy
@@ -1,0 +1,14 @@
+package fr.edf.jenkins.plugins.mac.MacHostFile
+
+import fr.edf.jenkins.plugins.mac.Messages
+
+def f = namespace(lib.FormTagLib)
+def c = namespace(lib.CredentialsTagLib)
+
+f.entry(title:_(Messages.Keychain_DisplayName()), field:"hostFileCredentialsId") {
+    c.select(context: app, includeUser: false, expressionAllowed: false)
+}
+
+f.entry(title: Messages.HostFile_HostPath(), field: 'hostPath') {
+    f.textbox()
+}

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHostFile/help-hostFileCredentialsId.html
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHostFile/help-hostFileCredentialsId.html
@@ -1,0 +1,1 @@
+The secret file credentials item

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHostFile/help-hostPath.html
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHostFile/help-hostPath.html
@@ -1,0 +1,1 @@
+The path on the host to upload the file to relative to the user's home folder (/Users/<username>/)

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
@@ -35,6 +35,7 @@ Host.Details=Host details
 Host.PreLaunchCommand=Pre-launch Command
 Host.UserManagementTool= User management tool
 Host.AgentJVMParameters= Agent JVM Parameters
+Host.File=Host files
 
 # MacComputerJNLPConnector
 Connector.JenkinsUrl=Jenkins URL
@@ -58,6 +59,13 @@ MacSlave.Executors=# of executors
 MacSlave.RemoteFSRoot=Remote FS root
 MacSlave.Labels=Labels
 MacSlave.NodeProperties=Node Properties
+
+# HostFile
+HostFile.DisplayName=Host file
+HostFile.HostFileCredentialsId=Credentials Id
+HostFile.HostPath=Host path
+HostFile.Add=Add host file
+HostFile.Delete=Delete host file
 
 # MacHostKeyVerifier
 MacHostKeyVerifier.HostKey=Host Key

--- a/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
@@ -33,7 +33,8 @@ class MacPojoBuilder {
                 "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZw==", //macHostKeyVerifier
                 "ls \n pwd \n whoami", //preLaunchCommands
                 Constants.SYSADMINCTL, //userManagementTool
-                "-Xms64m -Xmx128m" //agentJvmParameters
+                "-Xms64m -Xmx128m", //agentJvmParameters,
+                [] // host files
                 )
         List<MacHost> hostList = new ArrayList()
         hostList.add(host)


### PR DESCRIPTION
This change adds a config option for the host to allow selecting Jenkins File Credentials items to be uploaded to a path relative to the agent's User home folder, this was useful to me in some cases where I was using tools requiring specific config files including password / tokens etc (.npmrc, .aws config, ssh config)

Pretty similar to #15 but I needed it to be more generic

Unsure to write tests for such a feature since I'm pretty new to Jenkins plugins, would love some guidance in this area

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
