### PR TITLE
Disable a Mac host for a time when Jenkins cannot connect it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.46</version>
+        <version>4.47</version>
         <relativePath />
     </parent>
     <groupId>fr.edf.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -127,6 +129,15 @@
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>4.7.2.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -129,15 +127,6 @@
         </dependency>
     </dependencies>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>com.github.spotbugs</groupId>
-                    <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.7.2.0</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacCloud.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacCloud.groovy
@@ -20,6 +20,8 @@ import hudson.slaves.NodeProvisioner.PlannedNode
 
 class MacCloud extends Cloud {
 
+    private static final int ERROR_DURATION_DEFAULT_SECONDS = 300; // 5min
+
     private static final Logger LOGGER = Logger.getLogger(MacCloud.name)
 
     List<MacHost> macHosts = new ArrayList()
@@ -143,7 +145,7 @@ class MacCloud extends Cloud {
      * @param error : Reason
      */
     private void disableHost(MacHost host, SSHCommandException error) {
-        final long milliseconds = host.getErrorDuration() != null ? host.getErrorDuration()*1000 : 300000
+        final long milliseconds = host.getErrorDuration() != null ? host.getErrorDuration()*1000 : ERROR_DURATION_DEFAULT_SECONDS * 1000
         if (milliseconds > 0L) {
             final MacDisabled reasonForDisablement = host.getDisabled()
             reasonForDisablement.disableBySystem("Cloud provisioning failure", milliseconds, error)

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacCloud.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacCloud.groovy
@@ -1,5 +1,7 @@
 package fr.edf.jenkins.plugins.mac
 
+import static fr.edf.jenkins.plugins.mac.util.Constants.ERROR_DURATION_DEFAULT_SECONDS
+
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -19,8 +21,6 @@ import hudson.slaves.Cloud
 import hudson.slaves.NodeProvisioner.PlannedNode
 
 class MacCloud extends Cloud {
-
-    private static final int ERROR_DURATION_DEFAULT_SECONDS = 300; // 5min
 
     private static final Logger LOGGER = Logger.getLogger(MacCloud.name)
 

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
@@ -1,0 +1,225 @@
+package fr.edf.jenkins.plugins.mac
+
+import java.util.concurrent.TimeUnit
+
+import javax.annotation.Nonnull
+import javax.annotation.Nullable
+
+import org.kohsuke.accmod.Restricted
+import org.kohsuke.accmod.restrictions.NoExternalUse
+import org.kohsuke.stapler.DataBoundConstructor
+import org.kohsuke.stapler.DataBoundSetter
+import org.kohsuke.stapler.QueryParameter
+
+import hudson.Extension
+import hudson.Functions
+import hudson.Util
+import hudson.model.AbstractDescribableImpl
+import hudson.model.Descriptor
+import hudson.util.FormValidation
+
+public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements Serializable {
+
+    static final long serialVersionUID = 1L
+
+    boolean disabledByChoice = false
+
+    transient boolean disabledBySystem
+    transient long nanotimeWhenDisabledBySystem
+    transient long nanotimeWhenReEnableBySystem
+    transient String reasonWhyDisabledBySystem
+    transient Throwable exceptionWhenDisabledBySystem
+
+    // Persistence functionality
+
+    @DataBoundConstructor
+    public MacDisabled() {
+        // Sonar happy
+    }
+
+    /**
+     * Set a WindowsHost as disabled
+     * 
+     * @param disabledByChoice : boolean
+     */
+    @DataBoundSetter
+    public void setDisabledByChoice(final boolean disabledByChoice) {
+        this.disabledByChoice = disabledByChoice
+    }
+
+    // Internal use functionality
+
+    /**
+     * Called from owning classes to record a problem that will cause
+     * {@link #isDisabled()} to return true for a period.
+     * 
+     * @param reasonGiven            Human-readable String stating why.
+     * @param durationInMilliseconds Length of time, in milliseconds, the
+     *                               disablement should continue.
+     * @param exception              Optional exception.
+     */
+    @Restricted(NoExternalUse.class)
+    public void disableBySystem(@Nonnull final String reasonGiven, final long durationInMilliseconds,
+            @Nullable final Throwable exception) {
+        final long durationInNanoseconds = TimeUnit.MILLISECONDS.toNanos(durationInMilliseconds)
+        final long now = readTimeNowInNanoseconds()
+        disabledBySystem = true
+        nanotimeWhenDisabledBySystem = now
+        nanotimeWhenReEnableBySystem = now + durationInNanoseconds
+        reasonWhyDisabledBySystem = reasonGiven
+        exceptionWhenDisabledBySystem = exception
+    }
+
+    /**
+     * Indicates if we are currently disabled for any reason (either the user has
+     * ticked the disable box or {@link #disableBySystem(String, long, Throwable)}
+     * has been called recently).
+     * 
+     * @return true if we are currently disabled.
+     */
+    @Restricted(NoExternalUse.class)
+    public boolean isDisabled() {
+        return isDisabledByChoice() || isDisabledBySystem()
+    }
+
+    public boolean isDisabledBySystem() {
+        if (disabledBySystem) {
+            final long now = readTimeNowInNanoseconds()
+            final long disabledTimeRemaining = nanotimeWhenReEnableBySystem - now
+            if (disabledTimeRemaining > 0) {
+                return true
+            }
+            disabledBySystem = false
+            nanotimeWhenDisabledBySystem = 0L
+            nanotimeWhenReEnableBySystem = 0L
+            reasonWhyDisabledBySystem = null
+            exceptionWhenDisabledBySystem = null
+        }
+        return false
+    }
+
+    /** @return How long ago this was disabled by the system, e.g. "3 min 0 sec". */
+    public String getWhenDisabledBySystemString() {
+        if (!isDisabledBySystem()) {
+            return ""
+        }
+        final long now = readTimeNowInNanoseconds()
+        final long howLongAgoInNanoseconds = now - nanotimeWhenDisabledBySystem
+        final long howLongAgoInMilliseconds = TimeUnit.NANOSECONDS.toMillis(howLongAgoInNanoseconds)
+        return Util.getTimeSpanString(howLongAgoInMilliseconds)
+    }
+
+    /**
+     * @return How long ago this will remain disabled by the system, e.g. "2 min 0
+     *         sec".
+     */
+    public String getWhenReEnableBySystemString() {
+        final long now = readTimeNowInNanoseconds()
+        if (!isDisabledBySystem()) {
+            return ""
+        }
+        final long howSoonInNanoseconds = nanotimeWhenReEnableBySystem - now
+        final long howSoonInMilliseconds = TimeUnit.NANOSECONDS.toMillis(howSoonInNanoseconds)
+        return Util.getTimeSpanString(howSoonInMilliseconds)
+    }
+
+    public String getReasonWhyDisabledBySystem() {
+        if (!isDisabledBySystem()) {
+            return ""
+        }
+        return reasonWhyDisabledBySystem
+    }
+
+    public String getExceptionWhenDisabledBySystemString() {
+        if (!isDisabledBySystem() || exceptionWhenDisabledBySystem == null) {
+            return ""
+        }
+        return Functions.printThrowable(exceptionWhenDisabledBySystem)
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<MacDisabled> {
+        public FormValidation doCheckEnabledByChoice(@QueryParameter boolean disabledByChoice,
+                @QueryParameter boolean disabledBySystem, @QueryParameter String whenDisabledBySystemString,
+                @QueryParameter String whenReEnableBySystemString, @QueryParameter String reasonWhyDisabledBySystem,
+                @QueryParameter String exceptionWhenDisabledBySystemString) {
+            if (disabledByChoice) {
+                return FormValidation.warning("Note: Disabled.")
+            }
+            if (disabledBySystem) {
+                final String reason = Util.fixNull(reasonWhyDisabledBySystem)
+                final String disabledAgo = Util.fixNull(whenDisabledBySystemString)
+                final String enableWhen = Util.fixNull(whenReEnableBySystemString)
+                final String exception = Util.fixNull(exceptionWhenDisabledBySystemString)
+                if (!reason.isEmpty() && !disabledAgo.isEmpty() && !enableWhen.isEmpty()) {
+                    final StringBuilder html = new StringBuilder()
+                    html.append("Note: Disabled ")
+                    html.append(Util.escape(disabledAgo))
+                    html.append(" ago due to error.")
+                    html.append("  Will re-enable in ")
+                    html.append(Util.escape(enableWhen))
+                    html.append(".")
+                    html.append("<br/>Reason: ")
+                    html.append(Util.escape(reason))
+                    if (!exception.isEmpty()) {
+                        html.append(" <a href='#' class='showDetails'>")
+                        html.append(Messages.MacDisabled_ShowDetails())
+                        html.append("</a><pre style='display:none'>")
+                        html.append(Util.escape(exception))
+                        html.append("</pre>")
+                    }
+                    return FormValidation.warningWithMarkup(html.toString())
+                }
+            }
+            return FormValidation.ok()
+        }
+    }
+
+    // Basic Java Object methods
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false
+        }
+        final MacDisabled other = (MacDisabled) o
+        if (disabledByChoice != other.disabledByChoice) {
+            return false
+        }
+        return true
+    }
+
+    @Override
+    public int hashCode() {
+        int result = disabledByChoice ? 1 : 0
+        return result
+    }
+
+    @Override
+    public String toString() {
+        final boolean ByChoice = getDisabledByChoice()
+        final boolean bySystem = isDisabledBySystem()
+        if (bySystem) {
+            final String ago = getWhenDisabledBySystemString()
+            final String until = getWhenReEnableBySystemString()
+            final String why = getReasonWhyDisabledBySystem()
+            if (ByChoice) {
+                return "ByChoice,BySystem," + ago + "," + until + "," + why
+            }
+            return "BySystem," + ago + "," + until + "," + why
+        }
+        if (ByChoice) {
+            return "ByChoice"
+        }
+        return "No"
+    }
+
+    // Test accessor
+    @Restricted(NoExternalUse.class)
+    protected long readTimeNowInNanoseconds() {
+        return System.nanoTime()
+    }
+}

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
@@ -10,6 +10,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.DataBoundSetter
 import org.kohsuke.stapler.QueryParameter
+import org.kohsuke.stapler.verb.POST
 
 import hudson.Extension
 import hudson.Functions
@@ -139,7 +140,9 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
 
     @Extension
     static class DescriptorImpl extends Descriptor<MacDisabled> {
-        FormValidation doCheckEnabledByChoice(@QueryParameter boolean disabledByChoice,
+
+        @POST
+        FormValidation doCheckDisabledByChoice(@QueryParameter boolean disabledByChoice,
                 @QueryParameter boolean disabledBySystem, @QueryParameter String whenDisabledBySystemString,
                 @QueryParameter String whenReEnableBySystemString, @QueryParameter String reasonWhyDisabledBySystem,
                 @QueryParameter String exceptionWhenDisabledBySystemString) {

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
@@ -43,7 +43,7 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
      * @param disabledByChoice : boolean
      */
     @DataBoundSetter
-    public void setDisabledByChoice(final boolean disabledByChoice) {
+    void setDisabledByChoice(final boolean disabledByChoice) {
         this.disabledByChoice = disabledByChoice
     }
 
@@ -59,7 +59,7 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
      * @param exception              Optional exception.
      */
     @Restricted(NoExternalUse.class)
-    public void disableBySystem(@Nonnull final String reasonGiven, final long durationInMilliseconds,
+    void disableBySystem(@Nonnull final String reasonGiven, final long durationInMilliseconds,
             @Nullable final Throwable exception) {
         final long durationInNanoseconds = TimeUnit.MILLISECONDS.toNanos(durationInMilliseconds)
         final long now = readTimeNowInNanoseconds()
@@ -78,11 +78,11 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
      * @return true if we are currently disabled.
      */
     @Restricted(NoExternalUse.class)
-    public boolean isDisabled() {
+    boolean isDisabled() {
         return isDisabledByChoice() || isDisabledBySystem()
     }
 
-    public boolean isDisabledBySystem() {
+    boolean isDisabledBySystem() {
         if (disabledBySystem) {
             final long now = readTimeNowInNanoseconds()
             final long disabledTimeRemaining = nanotimeWhenReEnableBySystem - now
@@ -99,7 +99,7 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
     }
 
     /** @return How long ago this was disabled by the system, e.g. "3 min 0 sec". */
-    public String getWhenDisabledBySystemString() {
+    String getWhenDisabledBySystemString() {
         if (!isDisabledBySystem()) {
             return ""
         }
@@ -113,7 +113,7 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
      * @return How long ago this will remain disabled by the system, e.g. "2 min 0
      *         sec".
      */
-    public String getWhenReEnableBySystemString() {
+    String getWhenReEnableBySystemString() {
         final long now = readTimeNowInNanoseconds()
         if (!isDisabledBySystem()) {
             return ""
@@ -123,14 +123,14 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
         return Util.getTimeSpanString(howSoonInMilliseconds)
     }
 
-    public String getReasonWhyDisabledBySystem() {
+    String getReasonWhyDisabledBySystem() {
         if (!isDisabledBySystem()) {
             return ""
         }
         return reasonWhyDisabledBySystem
     }
 
-    public String getExceptionWhenDisabledBySystemString() {
+    String getExceptionWhenDisabledBySystemString() {
         if (!isDisabledBySystem() || exceptionWhenDisabledBySystem == null) {
             return ""
         }
@@ -138,8 +138,8 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<MacDisabled> {
-        public FormValidation doCheckEnabledByChoice(@QueryParameter boolean disabledByChoice,
+    static class DescriptorImpl extends Descriptor<MacDisabled> {
+        FormValidation doCheckEnabledByChoice(@QueryParameter boolean disabledByChoice,
                 @QueryParameter boolean disabledBySystem, @QueryParameter String whenDisabledBySystemString,
                 @QueryParameter String whenReEnableBySystemString, @QueryParameter String reasonWhyDisabledBySystem,
                 @QueryParameter String exceptionWhenDisabledBySystemString) {
@@ -178,7 +178,7 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
     // Basic Java Object methods
 
     @Override
-    public boolean equals(Object o) {
+    boolean equals(Object o) {
         if (this == o) {
             return true
         }
@@ -193,13 +193,13 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
     }
 
     @Override
-    public int hashCode() {
+    int hashCode() {
         int result = disabledByChoice ? 1 : 0
         return result
     }
 
     @Override
-    public String toString() {
+    String toString() {
         final boolean ByChoice = getDisabledByChoice()
         final boolean bySystem = isDisabledBySystem()
         if (bySystem) {

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacDisabled.groovy
@@ -175,29 +175,6 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
         }
     }
 
-    // Basic Java Object methods
-
-    @Override
-    boolean equals(Object o) {
-        if (this == o) {
-            return true
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false
-        }
-        final MacDisabled other = (MacDisabled) o
-        if (disabledByChoice != other.disabledByChoice) {
-            return false
-        }
-        return true
-    }
-
-    @Override
-    int hashCode() {
-        int result = disabledByChoice ? 1 : 0
-        return result
-    }
-
     @Override
     String toString() {
         final boolean ByChoice = getDisabledByChoice()
@@ -221,5 +198,20 @@ public class MacDisabled extends AbstractDescribableImpl<MacDisabled> implements
     @Restricted(NoExternalUse.class)
     protected long readTimeNowInNanoseconds() {
         return System.nanoTime()
+    }
+
+    /**
+     * Makes Spotbug happy by avoiding SE_TRANSIENT_FIELD_NOT_RESTORED
+     * 
+     * @return this
+     * @throws ObjectStreamException
+     */
+    private Object readResolve() throws ObjectStreamException {
+        disabledBySystem = false
+        nanotimeWhenDisabledBySystem = 0L
+        nanotimeWhenReEnableBySystem = 0L
+        reasonWhyDisabledBySystem = null
+        exceptionWhenDisabledBySystem = null
+        return this
     }
 }

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
@@ -37,7 +37,8 @@ class MacHost implements Describable<MacHost> {
     Integer kexTimeout
     Integer agentConnectionTimeout
     Integer maxTries
-    Boolean disabled
+    MacDisabled disabled
+    Integer errorDuration
     Boolean uploadKeychain = Boolean.FALSE
     String labelString
     String fileCredentialsId

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
@@ -51,7 +51,7 @@ class MacHost implements Describable<MacHost> {
 
     @DataBoundConstructor
     MacHost(String host, String credentialsId, Integer port, Integer maxUsers, Integer connectionTimeout, Integer readTimeout, Integer agentConnectionTimeout,
-    Boolean disabled, Integer maxTries, String labelString, Boolean uploadKeychain, String fileCredentialsId, List<MacEnvVar> envVars, String key,
+    MacDisabled disabled, Integer maxTries, String labelString, Boolean uploadKeychain, String fileCredentialsId, List<MacEnvVar> envVars, String key,
     String preLaunchCommands, String userManagementTool, String agentJvmParameters) {
         this.host = host
         this.credentialsId = credentialsId
@@ -119,7 +119,7 @@ class MacHost implements Describable<MacHost> {
     }
 
     @DataBoundSetter
-    void setDisabled(Boolean disabled) {
+    void setDisabled(MacDisabled disabled) {
         this.disabled = disabled
     }
 
@@ -292,7 +292,7 @@ class MacHost implements Describable<MacHost> {
          * @return ok if valid, error with exception message if not
          */
         @POST
-        public FormValidation doCheckKey(@QueryParameter String key) {
+        FormValidation doCheckKey(@QueryParameter String key) {
             return FormUtils.verifyHostKey(key)
         }
     }

--- a/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/MacHost.groovy
@@ -38,7 +38,7 @@ class MacHost implements Describable<MacHost> {
     Integer agentConnectionTimeout
     Integer maxTries
     MacDisabled disabled
-    Integer errorDuration
+    Integer errorDuration = Integer.valueOf(300)
     Boolean uploadKeychain = Boolean.FALSE
     String labelString
     String fileCredentialsId
@@ -52,7 +52,7 @@ class MacHost implements Describable<MacHost> {
     @DataBoundConstructor
     MacHost(String host, String credentialsId, Integer port, Integer maxUsers, Integer connectionTimeout, Integer readTimeout, Integer agentConnectionTimeout,
     MacDisabled disabled, Integer maxTries, String labelString, Boolean uploadKeychain, String fileCredentialsId, List<MacEnvVar> envVars, String key,
-    String preLaunchCommands, String userManagementTool, String agentJvmParameters) {
+    String preLaunchCommands, String userManagementTool, String agentJvmParameters, Integer errorDuration) {
         this.host = host
         this.credentialsId = credentialsId
         this.port = port
@@ -71,6 +71,7 @@ class MacHost implements Describable<MacHost> {
         this.preLaunchCommandsList = buildPreLaunchCommands(preLaunchCommands)
         this.userManagementTool = userManagementTool
         this.agentJvmParameters = agentJvmParameters
+        this.errorDuration = errorDuration
         labelSet = Label.parse(StringUtils.defaultIfEmpty(labelString, ""))
     }
 
@@ -173,6 +174,11 @@ class MacHost implements Describable<MacHost> {
     @DataBoundSetter
     void setUserManagementTool(String userManagementTool) {
         this.userManagementTool = userManagementTool
+    }
+
+    @DataBoundSetter
+    void setErrorDuration(Integer errorDuration) {
+        this.errorDuration = errorDuration
     }
 
     /**

--- a/src/main/java/fr/edf/jenkins/plugins/mac/slave/MacSlave.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/slave/MacSlave.groovy
@@ -28,6 +28,8 @@ import jenkins.model.Jenkins
 
 class MacSlave extends AbstractCloudSlave {
 
+    static final long serialVersionUID = 1L
+
     private static final Logger LOGGER = Logger.getLogger(MacSlave.name)
 
     final String cloudId

--- a/src/main/java/fr/edf/jenkins/plugins/mac/util/Constants.groovy
+++ b/src/main/java/fr/edf/jenkins/plugins/mac/util/Constants.groovy
@@ -19,6 +19,9 @@ class Constants {
     /** -Xms64m -Xmx128m */
     public static final String AGENT_JVM_DEFAULT_PARAMETERS = "-Xms64m -Xmx128m"
 
+    /** 300 sec */
+    public static final int ERROR_DURATION_DEFAULT_SECONDS = 300; // 5min
+
     //Username pattern
     /**"mac-[random_string]"*/
     public static final String USERNAME_PATTERN = "mac-%s"

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacDisabled/config.groovy
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacDisabled/config.groovy
@@ -1,0 +1,22 @@
+import fr.edf.jenkins.plugins.mac.Messages
+
+def f = namespace(lib.FormTagLib)
+
+f.entry(title:Messages.MacDisabled_Disable(), field:'disabledByChoice') {
+    f.checkbox(default:false)
+}
+f.invisibleEntry() {
+    f.checkbox(field:'disabledBySystem')
+}
+f.invisibleEntry() {
+    f.textbox(field:'whenDisabledBySystemString')
+}
+f.invisibleEntry() {
+    f.textbox(field:'whenReEnableBySystemString')
+}
+f.invisibleEntry() {
+    f.textbox(field:'reasonWhyDisabledBySystem')
+}
+f.invisibleEntry() {
+    f.textbox(field:'exceptionWhenDisabledBySystemString')
+}

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacDisabled/help-disabledByChoice.html
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacDisabled/help-disabledByChoice.html
@@ -1,0 +1,10 @@
+<div>
+    If not ticked then this functionality will be disabled.
+    <br/>
+    This can be used to e.g. take a cloud or template out of action for maintenance etc.
+    <p>
+    Note:
+    If problems are encountered then this functionality may be disabled automatically.
+    If that happens then it will be shown here.
+    In this situation, the disabled state is transient and will automatically clear after the stated period has elapsed.
+</div>

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
@@ -11,9 +11,7 @@ f.entry(title: _(Messages.Host_Host()), field: 'host') {
     f.textbox(clazz: 'required', checkMethod: 'post')
 }
 
-f.entry(title: Messages.Host_Disabled(), field:'disabled') {
-    f.checkbox()
-}
+f.property(field:'disabled') {}
 
 f.advanced(title:Messages.Host_Details()) {
 

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/config.groovy
@@ -53,6 +53,10 @@ f.advanced(title:Messages.Host_Details()) {
 
     f.advanced('Advanced settings') {
 
+        f.entry(title: _(Messages.Host_ErrorDuration()), field: 'errorDuration') {
+            f.number(clazz: 'required', default: 300, min: 0)
+        }
+
         f.entry(title: _(Messages.Host_AgentConnectionTimeout()), field: 'agentConnectionTimeout') {
             f.number(clazz: 'required', default: 15, min: 15)
         }

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/help-errorDuration.html
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/help-errorDuration.html
@@ -1,11 +1,15 @@
 <div>
+    <p>
     The duration (in seconds) for which the plugin will remember errors encountered during provisioning.
-    <br/>
+    </p>
+    <p>
     If an error is encountered while provisioning an agent on a Mac host
     then that host will be ignored for this duration,
     allowing Jenkins' subsequent provisioning attempts to use other (hopefully working) hosts
     (potentially on other clouds, if configured).
-    <br/>
+    </p>
+    <p>
     Defaults to 300 (5 minutes) if not set (or set to an invalid value).
     A value of zero disables this functionality (so that recent errors will not be taken into consideration when provisioning).
+    </p>
 </div>

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/help-errorDuration.html
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/MacHost/help-errorDuration.html
@@ -1,0 +1,11 @@
+<div>
+    The duration (in seconds) for which the plugin will remember errors encountered during provisioning.
+    <br/>
+    If an error is encountered while provisioning an agent on a Mac host
+    then that host will be ignored for this duration,
+    allowing Jenkins' subsequent provisioning attempts to use other (hopefully working) hosts
+    (potentially on other clouds, if configured).
+    <br/>
+    Defaults to 300 (5 minutes) if not set (or set to an invalid value).
+    A value of zero disables this functionality (so that recent errors will not be taken into consideration when provisioning).
+</div>

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
@@ -33,8 +33,9 @@ Host.Disabled=Disabled
 Host.MaxTries=Max connection retries
 Host.Details=Host details
 Host.PreLaunchCommand=Pre-launch Command
-Host.UserManagementTool= User management tool
-Host.AgentJVMParameters= Agent JVM Parameters
+Host.UserManagementTool=User management tool
+Host.AgentJVMParameters=Agent JVM Parameters
+Host.ErrorDuration=Error duration
 
 # MacComputerJNLPConnector
 Connector.JenkinsUrl=Jenkins URL

--- a/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
+++ b/src/main/resources/fr/edf/jenkins/plugins/mac/Messages.properties
@@ -68,3 +68,7 @@ MacHostKeyVerifier.Base64EncodedKeyValueRequired=The value part of the key shoul
 MacHostKeyVerifier.KeyValueDoesNotParse=Key value does not parse into a valid {0} key
 MacHostKeyVerifier.UnknownKeyAlgorithm=Key algorithm should be one of ssh-rsa or ssh-dss.
 MacHostKeyVerifier.UnexpectedKeyAlgorithm=Unexpected key algorithm: {0}
+
+#MacDisabled
+MacDisabled.Disable=Disable
+MacDisabled.ShowDetails=(show details)

--- a/src/test/java/fr/edf/jenkins/plugins/mac/MacDisabledTest.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/MacDisabledTest.groovy
@@ -1,0 +1,213 @@
+package fr.edf.jenkins.plugins.mac
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.startsWith
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNotEquals
+import static org.junit.Assert.assertTrue
+
+import java.util.concurrent.TimeUnit
+
+import org.junit.Test
+
+public class MacDisabledTest {
+
+    @Test
+    public void isDisabledGivenDefaultsThenReturnsFalse() {
+        final TestClass i = new TestClass()
+
+        final boolean actual = i.isDisabled()
+
+        assertFalse(actual)
+    }
+
+    @Test
+    public void isDisabledGivenUserNotDisabledThenReturnsFalse() {
+        final TestClass i = new TestClass()
+        i.setDisabledByChoice(false)
+
+        final boolean actual = i.isDisabled()
+
+        assertFalse(actual)
+    }
+
+    @Test
+    public void isDisabledGivenUserDisabledThenReturnsTrue() {
+        final TestClass i = new TestClass()
+        i.setDisabledByChoice(true)
+
+        final boolean actual = i.isDisabled()
+
+        assertTrue(actual)
+    }
+
+    @Test
+    public void isDisabledGivenSystemDisabledThenReturnsTrue() {
+        final TestClass i = new TestClass()
+        final long duration = 10000L
+        i.disableBySystem("non", duration, null)
+
+        final boolean actual = i.isDisabled()
+
+        assertTrue(actual)
+    }
+
+    @Test
+    public void isDisabledGivenSystemDisabledButTimeHasPassesThenReturnsFalseAfterTimeHasPassed() {
+        final TestClass i = new TestClass()
+        final long duration = 10000L
+        i.disableBySystem("non", duration, null)
+
+        final boolean actual1 = i.isDisabled()
+        i.moveTimeForwards(duration - 1)
+        final boolean actual2 = i.isDisabled()
+        i.moveTimeForwards(1)
+        final boolean actual3 = i.isDisabled()
+        i.moveTimeForwards(Long.MAX_VALUE)
+        final boolean actual4 = i.isDisabled()
+
+        assertTrue(actual1)
+        assertTrue(actual2)
+        assertFalse(actual3)
+        assertFalse(actual4)
+    }
+
+    @Test
+    public void getReasonWhyDisabledBySystemGivenGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass()
+
+        final String actual = i.getReasonWhyDisabledBySystem()
+
+        assertEquals("", actual)
+    }
+
+    @Test
+    public void getReasonWhyDisabledBySystemGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass()
+        final long duration = 10000L
+        final String reasonGiven = "SomeError"
+        i.disableBySystem(reasonGiven, duration, null)
+
+        final String actual1 = i.getReasonWhyDisabledBySystem()
+        i.moveTimeForwards(duration - 1)
+        final String actual2 = i.getReasonWhyDisabledBySystem()
+        i.moveTimeForwards(1)
+        final String actual3 = i.getReasonWhyDisabledBySystem()
+        i.moveTimeForwards(Long.MAX_VALUE)
+        final String actual4 = i.getReasonWhyDisabledBySystem()
+
+        assertEquals(reasonGiven, actual1)
+        assertEquals(reasonGiven, actual2)
+        assertEquals("", actual3)
+        assertEquals("", actual4)
+    }
+
+    @Test
+    public void getWhenDisabledBySystemStringGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass()
+
+        final String actual = i.getWhenDisabledBySystemString()
+
+        assertEquals("", actual)
+    }
+
+    @Test
+    public void getWhenDisabledBySystemStringGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass()
+        final long duration = 60001L
+        final String expected1 = "0 ms"
+        final String expected2 = "1 mn 0 s"
+        i.disableBySystem("a reason", duration, null)
+
+        final String actual1 = i.getWhenDisabledBySystemString()
+        i.moveTimeForwards(duration - 1)
+        final String actual2 = i.getWhenDisabledBySystemString()
+        i.moveTimeForwards(1)
+        final String actual3 = i.getWhenDisabledBySystemString()
+        i.moveTimeForwards(Long.MAX_VALUE)
+        final String actual4 = i.getWhenDisabledBySystemString()
+
+        assertEquals(expected1, actual1)
+        assertEquals(expected2, actual2)
+        assertEquals("", actual3)
+        assertEquals("", actual4)
+    }
+
+    @Test
+    public void getWhenReEnableBySystemStringGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass()
+
+        final String actual = i.getWhenReEnableBySystemString()
+
+        assertEquals("", actual)
+    }
+
+    @Test
+    public void getWhenReEnableBySystemStringGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass()
+        final long duration = 120000L
+        final String expected1 = "2 mn 0 s"
+        final String expected2 = "1 ms"
+        i.disableBySystem("another reason", duration, null)
+
+        final String actual1 = i.getWhenReEnableBySystemString()
+        i.moveTimeForwards(duration - 1)
+        final String actual2 = i.getWhenReEnableBySystemString()
+        i.moveTimeForwards(1)
+        final String actual3 = i.getWhenReEnableBySystemString()
+        i.moveTimeForwards(Long.MAX_VALUE)
+        final String actual4 = i.getWhenReEnableBySystemString()
+
+        assertEquals(expected1, actual1)
+        assertEquals(expected2, actual2)
+        assertEquals("", actual3)
+        assertEquals("", actual4)
+    }
+
+    @Test
+    public void getExceptionWhenDisabledBySystemStringGivenGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass()
+
+        final String actual = i.getExceptionWhenDisabledBySystemString()
+
+        assertEquals("", actual)
+    }
+
+    @Test
+    public void getExceptionWhenDisabledBySystemStringGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass()
+        final long duration = 10000L
+        final String reasonGiven = "SomeError"
+        final Throwable ex = new RuntimeException("FakeException")
+        final String expected = ex.toString()
+        i.disableBySystem(reasonGiven, duration, ex)
+
+        final String actual1 = i.getExceptionWhenDisabledBySystemString()
+        i.moveTimeForwards(duration - 1)
+        final String actual2 = i.getExceptionWhenDisabledBySystemString()
+        i.moveTimeForwards(1)
+        final String actual3 = i.getExceptionWhenDisabledBySystemString()
+        i.moveTimeForwards(Long.MAX_VALUE)
+        final String actual4 = i.getExceptionWhenDisabledBySystemString()
+
+        assertThat(actual1, startsWith(expected))
+        assertThat(actual2, startsWith(expected))
+        assertEquals("", actual3)
+        assertEquals("", actual4)
+    }
+
+    private static class TestClass extends MacDisabled {
+        long now = System.nanoTime()
+
+        @Override
+        protected long readTimeNowInNanoseconds() {
+            return now
+        }
+
+        public void moveTimeForwards(long milliseconds) {
+            final long nanos = TimeUnit.MILLISECONDS.toNanos(milliseconds)
+            now += nanos
+        }
+    }
+}

--- a/src/test/java/fr/edf/jenkins/plugins/mac/MacDisabledTest.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/MacDisabledTest.groovy
@@ -1,10 +1,7 @@
 package fr.edf.jenkins.plugins.mac
 
-import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.Matchers.startsWith
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNotEquals
 import static org.junit.Assert.assertTrue
 
 import java.util.concurrent.TimeUnit
@@ -191,8 +188,8 @@ public class MacDisabledTest {
         i.moveTimeForwards(Long.MAX_VALUE)
         final String actual4 = i.getExceptionWhenDisabledBySystemString()
 
-        assertThat(actual1, startsWith(expected))
-        assertThat(actual2, startsWith(expected))
+        assertTrue(actual1.startsWith(expected))
+        assertTrue(actual2.startsWith(expected))
         assertEquals("", actual3)
         assertEquals("", actual4)
     }

--- a/src/test/java/fr/edf/jenkins/plugins/mac/MacDisabledTest.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/MacDisabledTest.groovy
@@ -114,7 +114,8 @@ public class MacDisabledTest {
         final TestClass i = new TestClass()
         final long duration = 60001L
         final String expected1 = "0 ms"
-        final String expected2 = "1 mn 0 s"
+        final String expected2Min = "1"
+        final String expected2Sec = "0"
         i.disableBySystem("a reason", duration, null)
 
         final String actual1 = i.getWhenDisabledBySystemString()
@@ -126,7 +127,8 @@ public class MacDisabledTest {
         final String actual4 = i.getWhenDisabledBySystemString()
 
         assertEquals(expected1, actual1)
-        assertEquals(expected2, actual2)
+        assertEquals(expected2Min, actual2.split(" ")[0])
+        assertEquals(expected2Sec, actual2.split(" ")[2])
         assertEquals("", actual3)
         assertEquals("", actual4)
     }
@@ -144,7 +146,8 @@ public class MacDisabledTest {
     public void getWhenReEnableBySystemStringGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
         final TestClass i = new TestClass()
         final long duration = 120000L
-        final String expected1 = "2 mn 0 s"
+        final String expectedMin1 = "2"
+        final String expectedSec1 = "0"
         final String expected2 = "1 ms"
         i.disableBySystem("another reason", duration, null)
 
@@ -156,7 +159,8 @@ public class MacDisabledTest {
         i.moveTimeForwards(Long.MAX_VALUE)
         final String actual4 = i.getWhenReEnableBySystemString()
 
-        assertEquals(expected1, actual1)
+        assertEquals(expectedMin1, actual1.split(" ")[0])
+        assertEquals(expectedSec1, actual1.split(" ")[2])
         assertEquals(expected2, actual2)
         assertEquals("", actual3)
         assertEquals("", actual4)

--- a/src/test/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommandTest.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/ssh/SSHCommandTest.groovy
@@ -4,6 +4,7 @@ import org.jenkinsci.plugins.plaincredentials.FileCredentials
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 
+import fr.edf.jenkins.plugins.mac.MacDisabled
 import fr.edf.jenkins.plugins.mac.MacHost
 import fr.edf.jenkins.plugins.mac.MacUser
 import fr.edf.jenkins.plugins.mac.ssh.connection.SSHConnectionFactory
@@ -23,6 +24,7 @@ class SSHCommandTest extends Specification {
         setup:
         String label = "label"
         MacHost macHost = Mock(MacHost)
+        MacDisabled macDisabled = Mock(MacDisabled)
         MacUser user = SSHCommand.generateUser()
         GroovySpy(SSHCommandLauncher, global:true)
         1 * SSHCommandLauncher.executeCommand(_, true, String.format(Constants.CREATE_USER, user.username, user.password.getPlainText())) >> "OK"

--- a/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
@@ -3,6 +3,7 @@ package fr.edf.jenkins.plugins.mac.test.builders
 import org.jvnet.hudson.test.JenkinsRule
 
 import fr.edf.jenkins.plugins.mac.MacCloud
+import fr.edf.jenkins.plugins.mac.MacDisabled
 import fr.edf.jenkins.plugins.mac.MacEnvVar
 import fr.edf.jenkins.plugins.mac.MacHost
 import fr.edf.jenkins.plugins.mac.MacUser
@@ -24,7 +25,7 @@ class MacPojoBuilder {
                 5, //connectionTimeout
                 5, //readTimeout
                 15, //agentConnectionTimeout
-                false, //disabled
+                new MacDisabled(), //disabled
                 5, //maxTries
                 "testLabel", //label
                 Boolean.FALSE, //

--- a/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
+++ b/src/test/java/fr/edf/jenkins/plugins/mac/test/builders/MacPojoBuilder.groovy
@@ -34,7 +34,8 @@ class MacPojoBuilder {
                 "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZw==", //macHostKeyVerifier
                 "ls \n pwd \n whoami", //preLaunchCommands
                 Constants.SYSADMINCTL, //userManagementTool
-                "-Xms64m -Xmx128m" //agentJvmParameters
+                "-Xms64m -Xmx128m", //agentJvmParameters,
+                300 //errorDuration
                 )
         List<MacHost> hostList = new ArrayList()
         hostList.add(host)


### PR DESCRIPTION
### Actual Behavior :
A Mac host configured is disabled when Jenkins cannot contact it for 3 successives times.
A manual action in Jenkins cloud configuration is needed to enable the Host again.

### Target Behavior : 
A Mac host is disabled for a configurable time when Jenkins cannot contact it for 3 successives times.
The time is settable in the `Error Duration` field in the Mac Host configuration.
The host will be enable again when the time is up, like this no manual action is needed.
